### PR TITLE
Add Google Analytics using @next/third-parties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,9 @@
       "name": "spellcheck",
       "version": "0.1.0",
       "dependencies": {
-        "@vercel/analytics": "^1.5.0",
-        "@vercel/speed-insights": "^1.2.0",
+        "@next/third-parties": "^15.3.2",
+        "@vercel/analytics": "^1.2.2",
+        "@vercel/speed-insights": "^1.1.1",
         "nanoid": "^5.1.5",
         "next": "15.3.1",
         "react": "^19.0.0",
@@ -1865,6 +1866,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "15.3.2",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-15.3.2.tgz",
+      "integrity": "sha512-zE9xYkMKZ6gLbkP6lWt60yaeKB5r0A4eZhFKAhgik/eO+zzZPFkTy5K7+0ykgfB6MTkcend3BaDXZhz9KnDjYw==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -8759,6 +8773,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.13",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@next/third-parties": "^15.3.2",
     "@vercel/analytics": "^1.2.2",
     "@vercel/speed-insights": "^1.1.1",
     "nanoid": "^5.1.5",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import TopBar from "@/components/TopBar";
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
+import { GoogleAnalytics } from '@next/third-parties/google';
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -38,6 +39,7 @@ export default function RootLayout({
       </head>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased pt-16`}>
         <TopBar />
+        <GoogleAnalytics gaId="G-SFZLXFGSDV" />
         {children}
         <Analytics />
         <SpeedInsights />


### PR DESCRIPTION
This PR adds Google Analytics to the app using the @next/third-parties package and the provided measurement ID (G-SFZLXFGSDV). The GoogleAnalytics component is included in the root layout for site-wide analytics tracking, following Next.js best practices.