### PR TITLE
Fix daily puzzle timezone logic: transition at midnight local time (client-side date logic)

### DIFF
--- a/src/app/play/daily/page.tsx
+++ b/src/app/play/daily/page.tsx
@@ -7,7 +7,9 @@ import { useRouter } from 'next/navigation';
 
 function getTodayString() {
   const today = new Date();
-  return today.toLocaleDateString('en-CA');
+  const todayStr = today.toLocaleDateString('en-CA');
+  console.log('[DailyRedirectPage] todayStr:', todayStr, '| local datetime:', today.toString());
+  return todayStr;
 }
 
 export default function DailyRedirectPage() {

--- a/src/app/puzzle/[puzzle]/PuzzleClient.tsx
+++ b/src/app/puzzle/[puzzle]/PuzzleClient.tsx
@@ -1,3 +1,7 @@
+// This client component handles all date logic for daily puzzles.
+// Desired behavior: Daily puzzles should transition at midnight LOCAL TIME for the user (browser),
+// not the server's timezone. All date logic and daily puzzle gating is handled here for this reason.
+
 "use client";
 
 import { useMemo } from 'react';

--- a/src/app/puzzle/[puzzle]/PuzzleClient.tsx
+++ b/src/app/puzzle/[puzzle]/PuzzleClient.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useMemo } from 'react';
+import ChessBoard from '@/components/ChessBoard';
+import type { LoadedLevel } from '@/types/level';
+
+// Props for PuzzleClient, matching what the server passes
+interface PuzzleClientProps {
+  puzzleId: string;
+  puzzleDate: string | null;
+  puzzleType: 'short' | 'medium' | 'long' | null;
+  levelData: LoadedLevel;
+  nextPuzzleId: string | null;
+  congratsMessage: string;
+  hintSquares: string[] | null;
+  firstLetterSquare: string | null;
+  revealPath: string[] | null;
+}
+
+// Helper to format date header
+function formatDateHeader(dateStr: string): string {
+  const date = new Date(dateStr);
+  const options: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'long', day: 'numeric' };
+  return date.toLocaleDateString(undefined, options);
+}
+
+/**
+ * Client-side component for puzzle page.
+ *
+ * All date logic and header rendering is done here, using the user's local time.
+ * This avoids timezone bugs that occur if the server and client are in different timezones.
+ *
+ * If the puzzle is from the future (relative to the user's local time), shows a 'time traveler' message.
+ * Otherwise, renders the ChessBoard with the correct header and props.
+ */
+export default function PuzzleClient({
+  puzzleId,
+  puzzleDate,
+  puzzleType,
+  levelData,
+  nextPuzzleId,
+  congratsMessage,
+  hintSquares,
+  firstLetterSquare,
+  revealPath,
+}: PuzzleClientProps) {
+  // Get today's date in the user's local timezone
+  const todayStr = useMemo(() => {
+    return new Date().toLocaleDateString('en-CA');
+  }, []);
+
+  // Determine header and if this puzzle is from the future
+  let header = 'Puzzle';
+  let isFuture = false;
+  if (puzzleDate) {
+    if (puzzleDate === todayStr) {
+      header = `Daily Puzzle${puzzleType ? ' – ' + puzzleType.charAt(0).toUpperCase() + puzzleType.slice(1) : ''}`;
+    } else if (puzzleDate < todayStr) {
+      header = `${formatDateHeader(puzzleDate)}${puzzleType ? ' – ' + puzzleType.charAt(0).toUpperCase() + puzzleType.slice(1) : ''}`;
+    } else {
+      isFuture = true;
+    }
+  }
+
+  if (isFuture) {
+    return (
+      <main className="min-h-screen flex flex-col items-center justify-center bg-gray-50 dark:bg-gray-800">
+        <h1 className="text-2xl font-bold mb-4 dark:text-white">This puzzle is from the future!</h1>
+        <div className="bg-white dark:bg-gray-700 p-8 rounded-lg shadow-lg text-lg text-center">
+          <p>Whoa there, time traveler. This puzzle hasn&apos;t been released yet. Please be patient and try again on the correct day. The chessboard of destiny awaits, but not just yet.</p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center bg-gray-50 dark:bg-gray-800">
+      <h1 className="text-2xl font-bold mb-4 dark:text-white">{header}</h1>
+      <div className="bg-white dark:bg-gray-700 p-8 rounded-lg shadow-lg">
+        <ChessBoard
+          levelData={levelData}
+          nextPuzzleId={nextPuzzleId}
+          congratsMessage={congratsMessage}
+          puzzleId={puzzleId}
+          {...(hintSquares && firstLetterSquare && revealPath ? {
+            hintSquares,
+            firstLetterSquare,
+            revealPath
+          } : {})}
+        />
+      </div>
+    </main>
+  );
+} 

--- a/src/app/puzzle/[puzzle]/PuzzleClient.tsx
+++ b/src/app/puzzle/[puzzle]/PuzzleClient.tsx
@@ -44,10 +44,10 @@ export default function PuzzleClient({
   firstLetterSquare,
   revealPath,
 }: PuzzleClientProps) {
-  // Get today's date in the user's local timezone
-  const todayStr = useMemo(() => {
-    return new Date().toLocaleDateString('en-CA');
-  }, []);
+  // Use a single Date instance for both todayStr and the log
+  const today = useMemo(() => new Date(), []);
+  const todayStr = useMemo(() => today.toLocaleDateString('en-CA'), [today]);
+  console.log('[PuzzleClient] todayStr:', todayStr, '| local datetime:', today.toString());
 
   // Determine header and if this puzzle is from the future
   let header = 'Puzzle';

--- a/src/app/puzzle/[puzzle]/page.tsx
+++ b/src/app/puzzle/[puzzle]/page.tsx
@@ -1,4 +1,8 @@
-import dynamic from 'next/dynamic';
+// This server component loads puzzle data and passes it to the client-side PuzzleClient.
+// Desired behavior: Daily puzzles should transition at midnight LOCAL TIME for the client (user's browser),
+// not the server's timezone. All date logic and daily puzzle gating is handled in PuzzleClient.tsx.
+
+import PuzzleClient from './PuzzleClient';
 import { notFound } from 'next/navigation';
 import path from 'path';
 import fs from 'fs';
@@ -8,9 +12,6 @@ import { algebraicToPosition } from '@/utils/chess';
 import { LoadedLevel } from '@/types/level';
 import { ChessPiece } from '@/types/chess';
 import { getUnusedHintSquares, getFirstLetterHintSquare, getRevealAnswerPath } from '@/utils/hints';
-
-// Dynamically import the client-side PuzzleClient component
-const PuzzleClient = dynamic(() => import('./PuzzleClient'), { ssr: false });
 
 function getPuzzlePathFromId(id: string): string {
   const [wordLength] = id.split('-');

--- a/src/app/puzzle/[puzzle]/page.tsx
+++ b/src/app/puzzle/[puzzle]/page.tsx
@@ -1,26 +1,25 @@
+import dynamic from 'next/dynamic';
 import { notFound } from 'next/navigation';
 import path from 'path';
 import fs from 'fs';
 import { getDateForPuzzleId, getDailyPuzzlesForDate, getPuzzleTypeForId } from '@/utils/calendar';
-import ChessBoard from '@/components/ChessBoard';
 import { createEmptyBoard } from '@/utils/board';
 import { algebraicToPosition } from '@/utils/chess';
 import { LoadedLevel } from '@/types/level';
 import { ChessPiece } from '@/types/chess';
 import { getUnusedHintSquares, getFirstLetterHintSquare, getRevealAnswerPath } from '@/utils/hints';
 
+// Dynamically import the client-side PuzzleClient component
+const PuzzleClient = dynamic(() => import('./PuzzleClient'), { ssr: false });
+
 function getPuzzlePathFromId(id: string): string {
   const [wordLength] = id.split('-');
   return path.join(process.cwd(), 'src', 'puzzles', `${wordLength}_letter`, `puzzle_${id}.json`);
 }
 
-function formatDateHeader(dateStr: string): string {
-  const date = new Date(dateStr);
-  const options: Intl.DateTimeFormatOptions = { year: 'numeric', month: 'long', day: 'numeric' };
-  return date.toLocaleDateString(undefined, options);
-}
-
 export default async function PuzzlePage({ params }: { params: Promise<{ puzzle: string }> }) {
+  // Server-side: Only load puzzle data and related info, do NOT do any date logic here
+  // This avoids timezone bugs due to server/client differences
   const { puzzle: puzzleId } = await params;
   const puzzlePath = getPuzzlePathFromId(puzzleId);
   let puzzleData;
@@ -39,7 +38,6 @@ export default async function PuzzlePage({ params }: { params: Promise<{ puzzle:
     firstLetterSquare = await getFirstLetterHintSquare(puzzleId);
     revealPath = await getRevealAnswerPath(puzzleId);
   } catch {
-    // If hints fail, just don't show them
     hintSquares = null;
     firstLetterSquare = null;
     revealPath = null;
@@ -48,43 +46,6 @@ export default async function PuzzlePage({ params }: { params: Promise<{ puzzle:
   // Find the next puzzle in the daily sequence (if any)
   const puzzleDate = getDateForPuzzleId(puzzleId);
   const puzzleType = getPuzzleTypeForId(puzzleId);
-  const todayStr = new Date().toLocaleDateString('en-CA');
-
-  let header = '';
-  let isFuture = false;
-  if (puzzleDate) {
-    if (puzzleDate === todayStr) {
-      header = `Daily Puzzle${puzzleType ? ' – ' + puzzleType.charAt(0).toUpperCase() + puzzleType.slice(1) : ''}`;
-    } else if (puzzleDate < todayStr) {
-      header = `${formatDateHeader(puzzleDate)}${puzzleType ? ' – ' + puzzleType.charAt(0).toUpperCase() + puzzleType.slice(1) : ''}`;
-    } else {
-      isFuture = true;
-    }
-  } else {
-    header = 'Puzzle';
-  }
-
-  if (isFuture) {
-    return (
-      <main className="min-h-screen flex flex-col items-center justify-center bg-gray-50 dark:bg-gray-800">
-        <h1 className="text-2xl font-bold mb-4 dark:text-white">This puzzle is from the future!</h1>
-        <div className="bg-white dark:bg-gray-700 p-8 rounded-lg shadow-lg text-lg text-center">
-          <p>Whoa there, time traveler. This puzzle hasn&apos;t been released yet. Please be patient and try again on the correct day. The chessboard of destiny awaits, but not just yet.</p>
-        </div>
-      </main>
-    );
-  }
-
-  // Find the next puzzle in the daily sequence (if any)
-  let nextPuzzleId: string | null = null;
-  if (puzzleDate) {
-    const daily = getDailyPuzzlesForDate(puzzleDate);
-    if (daily) {
-      if (daily.short === puzzleId) nextPuzzleId = daily.medium;
-      else if (daily.medium === puzzleId) nextPuzzleId = daily.long;
-      else nextPuzzleId = null;
-    }
-  }
 
   // Prepare props for ChessBoard
   const targetWord = puzzleData.targetWords[0];
@@ -109,22 +70,30 @@ export default async function PuzzlePage({ params }: { params: Promise<{ puzzle:
     congratsMessage,
   };
 
+  // Find the next puzzle in the daily sequence (if any)
+  let nextPuzzleId: string | null = null;
+  if (puzzleDate) {
+    const daily = getDailyPuzzlesForDate(puzzleDate);
+    if (daily) {
+      if (daily.short === puzzleId) nextPuzzleId = daily.medium;
+      else if (daily.medium === puzzleId) nextPuzzleId = daily.long;
+      else nextPuzzleId = null;
+    }
+  }
+
+  // Pass all loaded data to the client-side PuzzleClient
+  // All date logic and header rendering is handled client-side to ensure correct timezone behavior
   return (
-    <main className="min-h-screen flex flex-col items-center justify-center bg-gray-50 dark:bg-gray-800">
-      <h1 className="text-2xl font-bold mb-4 dark:text-white">{header}</h1>
-      <div className="bg-white dark:bg-gray-700 p-8 rounded-lg shadow-lg">
-        <ChessBoard
-          levelData={levelData}
-          nextPuzzleId={nextPuzzleId}
-          congratsMessage={congratsMessage}
-          puzzleId={puzzleId}
-          {...(hintSquares && firstLetterSquare && revealPath ? {
-            hintSquares,
-            firstLetterSquare,
-            revealPath
-          } : {})}
-        />
-      </div>
-    </main>
+    <PuzzleClient
+      puzzleId={puzzleId}
+      puzzleDate={puzzleDate}
+      puzzleType={puzzleType}
+      levelData={levelData}
+      nextPuzzleId={nextPuzzleId}
+      congratsMessage={congratsMessage}
+      hintSquares={hintSquares}
+      firstLetterSquare={firstLetterSquare}
+      revealPath={revealPath}
+    />
   );
 } 

--- a/src/app/puzzle/[puzzle]/page.tsx
+++ b/src/app/puzzle/[puzzle]/page.tsx
@@ -46,13 +46,14 @@ export default async function PuzzlePage({ params }: { params: Promise<{ puzzle:
   // Find the next puzzle in the daily sequence (if any)
   const puzzleDate = getDateForPuzzleId(puzzleId);
   const puzzleType = getPuzzleTypeForId(puzzleId);
+  const daily = puzzleDate ? getDailyPuzzlesForDate(puzzleDate) : null;
 
   // Prepare props for ChessBoard
   const targetWord = puzzleData.targetWords[0];
   let congratsMessage = `Congratulations! You found the word ${targetWord}!`;
-  // If this is today's long puzzle, add extra congrats
-  const daily = getDailyPuzzlesForDate(todayStr);
-  if (daily && daily.long === puzzleId) {
+
+  // If this is the long puzzle for the day, add extra congrats
+  if (daily && puzzleType === 'long') {
     congratsMessage += ' You completed all the daily puzzles! See you tomorrow.';
   }
 
@@ -70,15 +71,12 @@ export default async function PuzzlePage({ params }: { params: Promise<{ puzzle:
     congratsMessage,
   };
 
-  // Find the next puzzle in the daily sequence (if any)
+  // Determine nextPuzzleId based on puzzleType
   let nextPuzzleId: string | null = null;
-  if (puzzleDate) {
-    const daily = getDailyPuzzlesForDate(puzzleDate);
-    if (daily) {
-      if (daily.short === puzzleId) nextPuzzleId = daily.medium;
-      else if (daily.medium === puzzleId) nextPuzzleId = daily.long;
-      else nextPuzzleId = null;
-    }
+  if (daily && puzzleType) {
+    if (puzzleType === 'short') nextPuzzleId = daily.medium;
+    else if (puzzleType === 'medium') nextPuzzleId = daily.long;
+    else nextPuzzleId = null;
   }
 
   // Pass all loaded data to the client-side PuzzleClient


### PR DESCRIPTION
## What
- Refactored puzzle page to split server/client logic for daily puzzles
- All date logic and daily puzzle gating is now handled in the client component (`PuzzleClient.tsx`)
- Added clear comments explaining that daily puzzles should transition at midnight local time for the user, not the server
- Added logging for todayStr and local datetime for manual verification

## Why
- Fixes bug where daily puzzle transition was based on server timezone, not user timezone
- Ensures users in different timezones (e.g., UK vs US) see new daily puzzles at their own midnight

## How
- Server component only loads puzzle data and passes to client
- Client component handles all date logic and gating
- Comments and logs added for clarity and debugging

---
Closes #timezone-bug